### PR TITLE
Write one file at a time

### DIFF
--- a/src/main/java/org/apache/kafka/connect/binary/BinarySourceTask.java
+++ b/src/main/java/org/apache/kafka/connect/binary/BinarySourceTask.java
@@ -105,7 +105,7 @@ public class BinarySourceTask extends SourceTask {
 
         if (use_dirwatcher == "true") {
             //consume here the pool
-            while (!((DirWatcher) task).getQueueFiles().isEmpty()) {
+            if (!((DirWatcher) task).getQueueFiles().isEmpty()) {
                 File file = ((DirWatcher) task).getQueueFiles().poll();
                 // creates the record
                 // no need to save offsets


### PR DESCRIPTION
if multiple files are copied in the watched directory, copy one file at a time and not all files together
